### PR TITLE
Fixes User Migration Failure

### DIFF
--- a/lib/generators/templates/migration_create_user.rb
+++ b/lib/generators/templates/migration_create_user.rb
@@ -5,7 +5,7 @@ class CreateUsers < ActiveRecord::Migration
         t.string :provider
         t.string :uid
         t.string :email
-        t.bigint :created
+        t.integer :created, :limit => 8
         t.string :username
         t.boolean :verified
         t.boolean :admin


### PR DESCRIPTION
When running a migration after `rails g dailycred`, the following error occurs.

```
rake db:migrate
==  CreateUsers: migrating ====================================================
-- create_table(:users)
rake aborted!
An error has occurred, this and all later migrations canceled:

undefined method `bigint' for #<ActiveRecord::ConnectionAdapters::TableDefinition:0x00000002058de8>
```

Judging by (this)[http://guides.rubyonrails.org/migrations.html#supported-types], Rails 3 does not have a `bigint` type. Rather, integers have variable length which can be controller [like so](http://stackoverflow.com/questions/1066340/how-to-use-long-id-in-rails-applications).

Hope this helps,
-- Lane Aasen
